### PR TITLE
fixes for new versions of networkx

### DIFF
--- a/pele/landscape/connect_manager.py
+++ b/pele/landscape/connect_manager.py
@@ -122,7 +122,7 @@ class ConnectManagerUntrap(BaseConnectManager):
         self.minpairs = deque()
         
         graph = TSGraph(self.database).graph
-        cclist = nx.connected_components(graph)
+        cclist = list(nx.connected_components(graph))
         
         # get the largest cluster
         group1 = cclist[0]
@@ -192,7 +192,7 @@ class ConnectManagerCombine(BaseConnectManager):
         self.minpairs = deque()
         
         graph = TSGraph(self.database).graph
-        cclist = nx.connected_components(graph)
+        cclist = list(nx.connected_components(graph))
 
         # remove clusters with fewer than clust_min
         cclist = [cc for cc in cclist if len(cc) >= self.clust_min]

--- a/pele/landscape/tests/test_graph.py
+++ b/pele/landscape/tests/test_graph.py
@@ -107,7 +107,7 @@ class TestGraph(unittest.TestCase):
     
     def test_connected_components(self):
         tsgraph = TSGraph(self.db)
-        cc = nx.connected_components(tsgraph.graph)
+        cc = list(nx.connected_components(tsgraph.graph))
         for nodes in cc:
             for u, v in izip(nodes[:-1], nodes[1:]):
                 self.assertTrue(tsgraph.areConnected(u, v))

--- a/pele/rates/_rate_calculations.py
+++ b/pele/rates/_rate_calculations.py
@@ -440,7 +440,7 @@ class GraphReduction(object):
 
         # check A and B are connected
         undirected_graph = self.graph.to_undirected()
-        cc = nx.connected_components(undirected_graph)
+        cc = list(nx.connected_components(undirected_graph))
         if len(cc) != 1:
 #            print "warning, graph is not fully connected.  There are", len(cc), "components"
             self._check_A_B_connected(cc)

--- a/pele/utils/disconnectivity_graph.py
+++ b/pele/utils/disconnectivity_graph.py
@@ -608,7 +608,7 @@ class DisconnectivityGraph(object):
         this was copied and only slightly modified from the original
         source
         """
-        cc=nx.connected_components(G)
+        cc = nx.connected_components(G)
         graph_list=[]
         for c in cc:
             graph_list.append(G.subgraph(c))
@@ -883,7 +883,7 @@ class DisconnectivityGraph(object):
         #make sure we include the subgraph containing min0
         if len(min0list) == 0:
             #use the biggest connected cluster
-            cc = nx.connected_components(graph)
+            cc = list(nx.connected_components(graph))
             used_nodes += cc[0] #list is ordered by size of cluster
         else:
             for min0 in min0list:


### PR DESCRIPTION
In newer versions of networkx the connected_components algorithms
implemented as generators rather than returing lists.  These changes
make pele play nice with both versions.

I noticed this because the travis tests started failing
