### PR TITLE
fix a bug in rigid body align

### DIFF
--- a/cpp_tests/source/test_aatopology.cpp
+++ b/cpp_tests/source/test_aatopology.cpp
@@ -388,6 +388,7 @@ TEST_F(AATopologyTest, MeasureAlign_Works)
     pele::MeasureAngleAxisCluster measure(rbtopology.get());
     measure.align(x1, x2);
 
+    // assert the com coordinates didn't change
     for (size_t i =0; i < nrigid*3; ++i) {
         ASSERT_DOUBLE_EQ(x2[i], x20[i]);
     }

--- a/pele/angleaxis/_cpp_aa.pyx
+++ b/pele/angleaxis/_cpp_aa.pyx
@@ -148,20 +148,20 @@ cdef class _cdef_MeasureAngleAxisCluster(object):
     def __cinit__(self, topology):
         # set up the cpp topology
         try:
+            # if topology is already a subclass of _cdef_RBTopology then this will work
             self.topology = topology
         except TypeError, e1:
-            try:
+            # topology is just the pythonic topology.  See if it has the cpp topology attached
+            if topology.cpp_topology is not None:
                 self.topology = topology.cpp_topology
-            except (TypeError, AttributeError):
-                print "can't set up the c++ topology"
-                print "first tried", e1
-                raise
+            else:
+                raise TypeError("can't set up the c++ topology needed for _cdef_MeasureAngleAxisCluster")
 
         self.thisptr = shared_ptr[cppMeasureAngleAxisCluster](
                   new cppMeasureAngleAxisCluster(self.topology.thisptr.get()))
     
     def align(self, x1, x2):
-        self.thisptr.get().align(array_wrap_np(x1), array_wrap_np(x1))
+        self.thisptr.get().align(array_wrap_np(x1), array_wrap_np(x2))
 
 cdef class _cdef_TransformAACluster(object):
     cdef shared_ptr[cppTransformAACluster] thisptr
@@ -169,14 +169,14 @@ cdef class _cdef_TransformAACluster(object):
     def __cinit__(self, topology):
         # set up the cpp topology
         try:
+            # if topology is already a subclass of _cdef_RBTopology then this will work
             self.topology = topology
         except TypeError, e1:
-            try:
+            # topology is just the pythonic topology.  See if it has the cpp topology attached
+            if topology.cpp_topology is not None:
                 self.topology = topology.cpp_topology
-            except (TypeError, AttributeError):
-                print "can't set up the c++ topology"
-                print "first tried", e1
-                raise
+            else:
+                raise TypeError("can't set up the c++ topology needed for _cdef_TransformAACluster")
 
         self.thisptr = shared_ptr[cppTransformAACluster](
                   new cppTransformAACluster(self.topology.thisptr.get()))
@@ -198,14 +198,14 @@ cdef class _cdef_RBPotentialWrapper(BasePotential):
 
         # set up the cpp topology
         try:
+            # if topology is already a subclass of _cdef_RBTopology then this will work
             self.topology = topology
         except TypeError, e1:
-            try:
+            # topology is just the pythonic topology.  See if it has the cpp topology attached
+            if topology.cpp_topology is not None:
                 self.topology = topology.cpp_topology
-            except (TypeError, AttributeError):
-                print "can't set up the c++ topology"
-                print "first tried", e1
-                raise
+            else:
+                raise TypeError("can't set up the c++ topology needed for _cdef_RBPotentialWrapper")
         
         assert self.topology is not None
             

--- a/pele/angleaxis/rigidbody.py
+++ b/pele/angleaxis/rigidbody.py
@@ -75,6 +75,7 @@ class RigidFragment(aatopology.AASiteType):
             position of the atom  sn402: I think this is in absolute Cartesian coords?
         mass: mass of the atom
         """
+        pos = np.array(pos, dtype=float)
         self.atom_types.append(atomtype)
         self.atom_positions.append(pos.copy())
         #print self.atom_positions
@@ -130,6 +131,7 @@ class RigidFragment(aatopology.AASiteType):
         return g_com, g_p
 
     def redistribute_forces(self, p, grad_com, grad_p):
+        # js850> as far as I can tell this is never used.  Maybe we should remove it?
         R, R1, R2, R3 = rotations.rot_mat_derivatives(p)
         grad = np.dot(R1, np.transpose(self.atom_positions)).transpose() * grad_p[0]
         grad += np.dot(R2, np.transpose(self.atom_positions)).transpose() * grad_p[1]
@@ -289,6 +291,7 @@ class RBTopology(aatopology.AATopology):
         return rbgrad.coords
 
     def redistribute_gradient(self, rbcoords, rbgrad):
+        # js850> as far as I can tell this is never used.  Maybe we should remove it?
         ca = self.coords_adapter(rbcoords)
         cg = self.coords_adapter(rbgrad)
         grad = np.zeros([self.natoms, 3])

--- a/pele/angleaxis/tests/test_aamindist.py
+++ b/pele/angleaxis/tests/test_aamindist.py
@@ -1,10 +1,16 @@
-import numpy as np
-from copy import deepcopy
-from pele.angleaxis.molecules import create_water
-from pele.angleaxis import RBTopology
-import pele.angleaxis.aamindist as am
-#import gmin_ as GMIN
 import unittest
+from copy import deepcopy
+
+import numpy as np
+
+from pele.angleaxis.molecules import create_water
+from pele.angleaxis import RBTopology, TransformAngleAxisCluster, MeasureAngleAxisCluster
+import pele.angleaxis.aamindist as am
+from pele.utils.rotations import random_aa, aa2mx
+from pele.utils import rotations
+from pele.potentials.tests._base_test import assert_arrays_almost_equal
+from pele.angleaxis.aatopology import AASiteType
+from pele.angleaxis.rigidbody import RigidFragment
 
 class TestAAMindist(unittest.TestCase):
     def setUp(self):
@@ -42,6 +48,104 @@ class TestAAMindist(unittest.TestCase):
             #print 
             self.assertAlmostEqual(measure1.get_dist(coords1, coords2),
                                    measure2.get_dist(coords1, coords2))
+    
+
+class TestAATransform(unittest.TestCase):
+    def setUp(self):
+        self.nrigid = 10
+        self.topology = RBTopology()
+        self.topology.add_sites([create_water() for _ in xrange(self.nrigid)])
+        self.topology.finalize_setup()
+        self.transform = TransformAngleAxisCluster(self.topology)
+    
+    def test_cpp_rotate(self):
+        x0 = np.array([random_aa() for _ in xrange(2*self.nrigid)]).ravel()
+        aa = random_aa()
+        mx = aa2mx(aa)
+        
+        x0_rotated = x0.copy()
+        self.transform.rotate(x0_rotated, mx)
+        
+        x0_rotated_python = x0.copy()
+        self.transform._rotate_python(x0_rotated_python, mx)
+        
+        assert_arrays_almost_equal(self, x0_rotated, x0_rotated_python)
+        
+        mx_reverse = aa2mx(-aa)
+        self.transform.rotate(x0_rotated, mx_reverse)
+        assert_arrays_almost_equal(self, x0, x0_rotated)
+
+def create_tetrahedron():
+    f = RigidFragment()
+    f.add_atom("h", [ 1., 0., -1./np.sqrt(2)])
+    f.add_atom("h", [-1., 0., -1./np.sqrt(2)])
+    f.add_atom("h", [0.,  1., 1./np.sqrt(2)])
+    f.add_atom("h", [0., -1., 1./np.sqrt(2)])
+    f.finalize_setup()
+    return f
+
+class TestAAMeasure(unittest.TestCase):
+    def setUp(self):
+        self.nrigid = 10
+        self.topology = RBTopology()
+        self.topology.add_sites([create_tetrahedron() for _ in xrange(self.nrigid)])
+        self.topology.finalize_setup()
+        self.measure = MeasureAngleAxisCluster(self.topology)
+    
+    def test_cpp_align(self):
+        x1 = np.array([random_aa() for _ in xrange(2*self.nrigid)]).ravel()
+        x2 = np.array([random_aa() for _ in xrange(2*self.nrigid)]).ravel()
+        
+        x1_cpp = x1.copy()
+        x2_cpp = x2.copy()
+        x1_python = x1.copy()
+        x2_python = x2.copy()
+        
+        ret = self.measure._align_pythonic(x1_python, x2_python)
+        self.assertIsNone(ret)
+        ret = self.measure.align(x1_cpp, x2_cpp)
+        self.assertIsNone(ret)
+        
+        assert_arrays_almost_equal(self, x1_python, x1)
+        assert_arrays_almost_equal(self, x1_cpp, x1)
+        
+        # assert that the center of mass coordinates didn't change
+        assert_arrays_almost_equal(self, x2_python[:3*self.nrigid], x2[:3*self.nrigid])
+        assert_arrays_almost_equal(self, x2_cpp[:3*self.nrigid], x2[:3*self.nrigid])
+        
+        # assert that x2 actually changed
+        max_change = np.max(np.abs(x2_cpp - x2))
+        self.assertGreater(max_change, 1e-3)
+
+        assert_arrays_almost_equal(self, x2_python, x2_cpp)
+
+    def test_align_bad_input(self):
+        x1 = np.array([random_aa() for _ in xrange(2*self.nrigid)]).ravel()
+        x2 = list(x1)
+        
+        with self.assertRaises(TypeError):
+            self.measure.align(x1, x2)
+
+    def test_symmetries(self):
+        tet = create_tetrahedron()
+        print tet.symmetries
+        self.assertEqual(len(tet.symmetries), 12)
+
+
+    def test_align_exact(self):
+        x1 = np.array([random_aa() for _ in xrange(2*self.nrigid)]).ravel()
+        x2 = x1.copy()
+        tet = create_tetrahedron()
+        mx = tet.symmetries[2].copy() 
+        p = x2[-3:].copy()
+        x2[-3:] = rotations.rotate_aa(rotations.mx2aa(mx), p)
+        
+        self.measure._align_pythonic(x1, x2)
+        assert_arrays_almost_equal(self, x1, x2)
+        
+
+
+
 
     
 if __name__ == '__main__':

--- a/pele/mindist/rmsfit.py
+++ b/pele/mindist/rmsfit.py
@@ -127,6 +127,9 @@ def findrotation_kearsley(coords1, coords2, align_com=True):
 
     dist = np.sqrt(eigmin) # this is the minimized distance between the two structures
 
+    Q2 = np.real_if_close(Q2, 1e-10)
+    if np.iscomplexobj(Q2):
+        raise ValueError("Q2 is complex")
     return dist, rotations.q2mx(Q2)
 
 findrotation = findrotation_kearsley

--- a/pele/potentials/_pele.pxd
+++ b/pele/potentials/_pele.pxd
@@ -80,7 +80,7 @@ cdef inline np.ndarray[double, ndim=1] pele_array_to_np(Array[double] v):
         vnew[i] = v[i]
     return vnew
     
-cdef inline Array[size_t] array_wrap_np_size_t(np.ndarray[size_t] v):
+cdef inline Array[size_t] array_wrap_np_size_t(np.ndarray[size_t] v) except *:
     """return a pele Array which wraps the data in a numpy array
     
     Notes
@@ -101,7 +101,7 @@ cdef inline np.ndarray[size_t, ndim=1] pele_array_to_np_size_t(Array[size_t] v):
         vnew[i] = v[i]
     return vnew
     
-cdef inline Array[long] array_wrap_np_long(np.ndarray[long] v):
+cdef inline Array[long] array_wrap_np_long(np.ndarray[long] v) except *:
     """return a pele Array which wraps the data in a numpy array
     
     Notes

--- a/pele/utils/_cpp_utils.pyx
+++ b/pele/utils/_cpp_utils.pyx
@@ -44,9 +44,11 @@ cdef extern from "pele/rotations.h" namespace "pele":
             Matrix33 & drm3) except +
 
 
-cdef Vec3 to_vec(p):
+cdef Vec3 to_vec(p) except *:
     cdef Vec3 v
-    assert len(p) == 3
+    p = np.asarray(p)
+    if p.size != 3:
+        raise ValueError("p must be a 3 element array or list")
     v[0] = p[0]
     v[1] = p[1]
     v[2] = p[2]
@@ -59,9 +61,11 @@ cdef np.ndarray[double] vec_to_np(Vec3 & p):
     v[2] = p[2]
     return v
 
-cdef Vec4 to_vec4(p):
+cdef Vec4 to_vec4(p) except *:
     cdef Vec4 v
-    assert len(p) == 4
+    p = np.asarray(p)
+    if p.size != 4:
+        raise ValueError("p must be a 4 element array or list")
     v[0] = p[0]
     v[1] = p[1]
     v[2] = p[2]
@@ -78,11 +82,8 @@ cdef np.ndarray[double] vec4_to_np(Vec4 & p):
 
 cdef Matrix33 to_mat(A) except *:
     cdef Matrix33 Anew
-    try:
-        A = A.reshape(-1)
-    except AttributeError:
-        pass
-    if len(A) != 9:
+    A = np.asarray(A).ravel()
+    if A.size != 9:
         print A
         raise ValueError("A should have length 9 but it is length " + str(len(A)) )
     cdef int i
@@ -100,7 +101,7 @@ cdef np.ndarray[double] mat_to_np(Matrix33 & A):
     return Anew.reshape([3,3])
 
 cpdef rotate_aa(p1, p2):
-    """change a given angle axis rotation p1 by the rotation p2
+    """change a given angle axis rotation p2 by the rotation p1
     """
     return vec_to_np(c_rotate_aa(to_vec(p1), to_vec(p2)))
 

--- a/pele/utils/rotations.py
+++ b/pele/utils/rotations.py
@@ -131,6 +131,7 @@ def mx2q(mi):
 
     if q[0] < 0:
         q = -q
+    
     return q
 
 

--- a/pele/utils/tests/test_rotations.py
+++ b/pele/utils/tests/test_rotations.py
@@ -42,8 +42,8 @@ def aa2mx(p):
 
 def rotate_aa(p1, p2):
     """
-    change a given angle axis rotation p1 by the
-    rotation p2
+    change a given angle axis rotation p2 by the
+    rotation p1
     """
     return q2aa(q_multiply(aa2q(p2), aa2q(p1)))
 


### PR DESCRIPTION
there was a typo in _cdef_MeasureAngleAxisCluster.align().  x1 was
passed as both x1 and x2.

Also
1. Add tests for rigid body measure.align and transform.rotate. (this was how I found the bug)
2. Ensure exceptions are handled in some of the cdef functions.
3. Ensure findrotation returns a real object
4. Fix the documentation for rotations.rotate_aa.  The order of the inputs
   is non-intuitive.
