### PR TITLE
stop saving the eigenvectors in the database

### DIFF
--- a/pele/landscape/connect_min.py
+++ b/pele/landscape/connect_min.py
@@ -276,7 +276,7 @@ class DoubleEndedConnect(object):
         logger.info("adding transition state %s %s", min1.id(), min2.id())
         # add the transition state to the database
         ts = self.database.addTransitionState(ts_ret.energy, ts_ret.coords, min1, min2,
-                                              eigenvec=ts_ret.eigenvec, eigenval=ts_ret.eigenval)
+                                              eigenval=ts_ret.eigenval)
         # update the transition state graph
         self.graph.addTransitionState(ts)
         # self.graph.refresh()

--- a/pele/storage/database.py
+++ b/pele/storage/database.py
@@ -216,8 +216,9 @@ class TransitionState(Base):
         else:
             self.minimum1 = min2
             self.minimum2 = min1
-            
-        self.eigenvec = np.copy(eigenvec)
+        
+        if eigenvec is not None:
+            self.eigenvec = np.copy(eigenvec)
         self.eigenval = eigenval
         self.invalid = False
 


### PR DESCRIPTION
they were not used anywhere, they can easily be recomputed if necessary, and they double the size of storing a transition state