### PR TITLE
change abs to std::abs, change variable name

### DIFF
--- a/source/lbfgs.cpp
+++ b/source/lbfgs.cpp
@@ -177,11 +177,11 @@ double LBFGS::backtracking_linesearch(Array<double> step)
 
         double df = fnew - f_;
         if (use_relative_f_) {
-            double fabs = 1e-100; 
+            double absf = 1e-100; 
             if (f_ != 0) {
-                fabs = abs(f_);
+                absf = std::abs(f_);
             }
-            df /= fabs;
+            df /= absf;
         }
         if (df < max_f_rise_){
             break;


### PR DESCRIPTION
Changes usage of abs, based on discussion with @js850 and this reference:
http://stackoverflow.com/a/3118188