### PR TITLE
Compatibility fix for config parser for both python 2 and python 3 to…

### DIFF
--- a/pele/config.py
+++ b/pele/config.py
@@ -1,8 +1,8 @@
 from __future__ import print_function
-import configparser
+from configparser import ConfigParser
 from os.path import expanduser
 
-config = configparser.ConfigParser()
+config = ConfigParser.ConfigParser()
 config.add_section("gui")
 config.set("gui", "use_pymol", value="False")
 


### PR DESCRIPTION
Config parser and config setting now working with python 2 (backward compatibility): Affected module: GUI