### PR TITLE
HOTFIX: NEB tangent estimation

### DIFF
--- a/pele/transition_states/_NEB.py
+++ b/pele/transition_states/_NEB.py
@@ -316,7 +316,7 @@ class NEB(object):
         tright = -gright
 
         # special interpolation treatment for maxima/minima
-        if (central >= left and central >= right) or (central <= left and central <= right):
+        if (central > left and central > right) or (central < left and central < right):
             if left > right:
                 t = vmax * tleft + vmin * tright
             else:
@@ -324,9 +324,12 @@ class NEB(object):
         # left is higher, take this one
         elif left > right:
             t = tleft
-        # otherwise take right
-        else:
+        # right is higher, take this one
+        elif left < right:
             t = tright
+        # flat section (i.e. all energy levels equal) -> fallback to original NEB tangent
+        else:
+            t = tleft / norm(tleft) + tright / norm(tright)
 
         return t / norm(t)
 


### PR DESCRIPTION
# Problem
When facing a flat energy spaces, i.e. the energies of three adjacent images are equal, the current tangent implementation uses the computation for extrema from [1]. 
However, in [1] this is only applicable if we are at a strict extreme. For the special case of a flat space, taking the same formula (as was done in the current implementation) leads to tangent becoming the zero vector. Thus, at the normalization an invalid value is encountered and NaNs are returned.
This problem then cascades towards failure of LBFGS since we have NaNs.

# Fix
On a flat spot, simply fall back to the original NEB tangent computation, taking the weighted average, where the weights are equal for the tangents on both sides.

# References
[1] G. Henkelman and H. Jónsson, “Improved tangent estimate in the nudged elastic band method for finding minimum energy paths and saddle points,” J. Chem. Phys., vol. 113, no. 22, pp. 9978–9985, Dec. 2000, doi: [10.1063/1.1323224](https://doi.org/10.1063/1.1323224).
